### PR TITLE
more readable alerts, resolve #3495

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -118,20 +119,35 @@ func main() {
 		}
 		log.Printf("Alert: %s", s)
 
-		groupLabels := make([]string, 0, len(alerts.GroupLabels))
+		keys := make([]string, 0, len(alerts.GroupLabels))
 		for k := range alerts.GroupLabels {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		groupLabels := make([]string, 0, len(alerts.GroupLabels))
+		for _, k := range keys {
 			groupLabels = append(groupLabels, fmt.Sprintf("%s=<pre>%s</pre>", k, alerts.GroupLabels[k]))
 		}
 
-		commonLabels := make([]string, 0, len(alerts.CommonLabels))
+		keys = make([]string, 0, len(alerts.CommonLabels))
 		for k := range alerts.CommonLabels {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		commonLabels := make([]string, 0, len(alerts.CommonLabels))
+		for _, k := range keys {
 			if _, ok := alerts.GroupLabels[k]; !ok {
 				commonLabels = append(commonLabels, fmt.Sprintf("%s=<pre>%s</pre>", k, alerts.CommonLabels[k]))
 			}
 		}
 
-		commonAnnotations := make([]string, 0, len(alerts.CommonAnnotations))
+		keys = make([]string, 0, len(alerts.CommonAnnotations))
 		for k := range alerts.CommonAnnotations {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		commonAnnotations := make([]string, 0, len(alerts.CommonAnnotations))
+		for _, k := range keys {
 			commonAnnotations = append(commonAnnotations, fmt.Sprintf("\n%s: <pre>%s</pre>", k, alerts.CommonAnnotations[k]))
 		}
 

--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ func main() {
 		sort.Strings(keys)
 		groupLabels := make([]string, 0, len(alerts.GroupLabels))
 		for _, k := range keys {
-			groupLabels = append(groupLabels, fmt.Sprintf("%s=<pre>%s</pre>", k, alerts.GroupLabels[k]))
+			groupLabels = append(groupLabels, fmt.Sprintf("%s=<code>%s</code>", k, alerts.GroupLabels[k]))
 		}
 
 		keys = make([]string, 0, len(alerts.CommonLabels))
@@ -137,7 +137,7 @@ func main() {
 		commonLabels := make([]string, 0, len(alerts.CommonLabels))
 		for _, k := range keys {
 			if _, ok := alerts.GroupLabels[k]; !ok {
-				commonLabels = append(commonLabels, fmt.Sprintf("%s=<pre>%s</pre>", k, alerts.CommonLabels[k]))
+				commonLabels = append(commonLabels, fmt.Sprintf("%s=<code>%s</code>", k, alerts.CommonLabels[k]))
 			}
 		}
 
@@ -148,7 +148,7 @@ func main() {
 		sort.Strings(keys)
 		commonAnnotations := make([]string, 0, len(alerts.CommonAnnotations))
 		for _, k := range keys {
-			commonAnnotations = append(commonAnnotations, fmt.Sprintf("\n%s: <pre>%s</pre>", k, alerts.CommonAnnotations[k]))
+			commonAnnotations = append(commonAnnotations, fmt.Sprintf("\n%s: <code>%s</code>", k, alerts.CommonAnnotations[k]))
 		}
 
 		alertDetails := make([]string, len(alerts.Alerts))


### PR DESCRIPTION
Я попытался на быструю руку подправить внешний вид алертов.
Основная проблема была в том, что метки выводились каждый раз в разном порядке.
Вторая проблема была в том, что в web.telegram.org значения меток отформатированные через `<pre>` выводились каждое на отдельной строке - заменил на `<code>` в надежде что это поможет, но не тестировал.

Изменения лучше смотреть по отдельным коммитам, будет нагляднее.