### PR TITLE
Add template

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,15 @@ For test your instance, you must only export TELEGRAM_CHATID environment variabl
 export TELEGRAM_CHATID="-YOUR TELEGRAM CHAT ID"
 make test
 ```
+
+## Customizing messages with template
+
+Bot support [go templating language](https://golang.org/pkg/text/template/).
+Use it for customizing your message.
+For enable template you must call bot with option -t template.tmpl
+
+
+```telegram_bot -t template.tmpl```
+
+Is provided a template file with all possibile variable, use ```make test``` for check, result message.
+Telegram support HTML check [here](https://core.telegram.org/bots/api#html-style) list of aviable tags.

--- a/template.tmpl
+++ b/template.tmpl
@@ -1,0 +1,42 @@
+
+{{.CommonAnnotations }}
+{{.CommonLabels}}
+{{.ExternalURL}}
+{{.GroupLabels}}
+{{.Receiver}}
+{{.Status}}
+
+<b>Active Alert List:</b>
+{{ range $val := .Alerts -}}
+
+{{range $ann := $val.Annotations -}}
+<b>Annotations:</b>
+{{$ann}}
+
+{{- end}}
+{{- end}}
+Version:{{.Version}}
+
+{{/*Possible variable of template
+  	Alerts            []Alert
+  	CommonAnnotations map[string]interface{}
+  	CommonLabels      map[string]interface{}
+  	ExternalURL       string
+  	GroupKey          int
+  	GroupLabels       map[string]interface{}
+  	Receiver          string
+  	Status            string
+  	Version
+
+    SubVariable Alert use make test for testing this
+
+  	Annotations  map[string]interface{}
+  	EndsAt       string
+  	GeneratorURL string                 `
+  	Labels       map[string]interface{}
+  	StartsAt     string
+
+    All MAP params are iterable with range.
+    About go template language take look:https://golang.org/pkg/text/template/
+
+  */}}


### PR DESCRIPTION
Add support for templating messages.
Now is possible, customizing final message with simple template: golang template language.
Use flag -t for trigger template behavior or sprintf behavior.

Andrea