### PR TITLE
Add Dockerfile for building with golang-builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM scratch
-EXPOSE 9087
+FROM alpine:3.5
+
+RUN apk add --no-cache ca-certificates
+
 COPY prometheus_bot /
+
+EXPOSE 9087
 ENTRYPOINT ["/prometheus_bot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+EXPOSE 9087
+COPY prometheus_bot /
+ENTRYPOINT ["/prometheus_bot"]

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-package main
+package main  // import "github.com/inCaller/prometheus_bot"
 
 import (
 	"bytes"


### PR DESCRIPTION
With these changes I managed to build prometheus_bot image using following [golang-builder](https://github.com/CenturyLinkLabs/golang-builder):

```
sudo docker run --rm \
    -v "$(pwd):/src" \
    -v /var/run/docker.sock:/var/run/docker.sock \
    centurylink/golang-builder rutsky/prometheus_bot:0.0.4
```

where last part (rutsky/prometheus_bot:0.0.4) is image name to use for storing in local Docker instance.
I pushed this image to Docker Hub here: https://hub.docker.com/r/rutsky/prometheus_bot/, and use it with `docker pull rutsky/prometheus_bot:0.0.4`.

This is not best setup that might be (best --- is autobuilding from tag on Github and publishing to Docker Hub), but it worked for me.

Related to #10.