### PR TITLE
Fix custom templates for messages

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 	"github.com/go-telegram-bot-api/telegram-bot-api"
 	"gopkg.in/yaml.v2"
 
-	"text/template"
+	"html/template"
 )
 
 type Alerts struct {

--- a/t/curl.t
+++ b/t/curl.t
@@ -5,7 +5,8 @@ echo "1..$(($(echo "$json_files"|wc -l) * $(printf "$template_files\n\n"|wc -l))
 echo -n "" > bot.log
 for template_file in "" $template_files
 do
-    ./prometheus_bot $(test -n "${template_file}" && echo "-d -t $template_file") >> bot.log 2>&1 &
+    echo "****** Run prometheus_bot with template ${template_file} ******" >> bot.log 2>&1
+    ./prometheus_bot $(test -n "${template_file}" && echo "-d -t ${template_file}") >> bot.log 2>&1 &
     sleep 3
     for json_file in $json_files
     do


### PR DESCRIPTION
- Fix https://github.com/inCaller/prometheus_bot/issues/13 (Flood by "Error sending message, checkout logs" messages)
- Fix https://github.com/inCaller/prometheus_bot/issues/14 (Template works only from current directory)
- Minor refactoring of template logic to avoid code repetition


FYI: I used `html/template` instead of `txt/template` for proper escaping, but it not fully solve the problem. To avoid a `503 Bad Request` from Telegram server you should follow this requirements to the HTML code: https://core.telegram.org/bots/api#html-style