### PR TITLE
Fix endsAt field

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ type Alerts struct {
 
 type Alert struct {
 	Annotations  map[string]interface{} `json:"annotations"`
-	EndsAt       string                 `json:"sendsAt"`
+	EndsAt       string                 `json:"endsAt"`
 	GeneratorURL string                 `json:"generatorURL"`
 	Labels       map[string]interface{} `json:"labels"`
 	StartsAt     string                 `json:"startsAt"`


### PR DESCRIPTION
This field was empty (alertmanager versions > 0.13)
Discussion on prometheus  google groups https://groups.google.com/forum/#!topic/prometheus-users/VXC_6uvkHSg