### PR TITLE
Add alert duration field [feature]

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ type Alert struct {
 	GeneratorURL string                 `json:"generatorURL"`
 	Labels       map[string]interface{} `json:"labels"`
 	StartsAt     string                 `json:"startsAt"`
+	Duration		 time.Duration
 }
 
 type Config struct {
@@ -547,6 +548,19 @@ func POST_Handling(c *gin.Context) {
 	}
 
 	binding.JSON.Bind(c.Request, &alerts)
+
+	for index, _ := range alerts.Alerts {
+		layout := "2006-01-02T15:04:05.000000000Z"
+		startsAt_time, err := time.Parse(layout, alerts.Alerts[index].StartsAt)
+		if err != nil {
+			log.Print(err)
+		}
+		endsAt_time, err := time.Parse(layout, alerts.Alerts[index].EndsAt)
+		if err != nil {
+			log.Print(err)
+		}
+		alerts.Alerts[index].Duration = endsAt_time.Sub(startsAt_time)
+	}
 
 	s, err := json.Marshal(alerts)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -550,17 +550,15 @@ func POST_Handling(c *gin.Context) {
 	binding.JSON.Bind(c.Request, &alerts)
 
 	for index, _ := range alerts.Alerts {
-		layout := "2006-01-02T15:04:05.000000000Z"
-		startsAt_time, err := time.Parse(layout, alerts.Alerts[index].StartsAt)
+		startsAt_time, err := time.Parse(time.RFC3339, alerts.Alerts[index].StartsAt)
 		if err != nil {
 			log.Print(err)
 		}
-		endsAt_time, err := time.Parse(layout, alerts.Alerts[index].EndsAt)
+		endsAt_time, err := time.Parse(time.RFC3339, alerts.Alerts[index].EndsAt)
 		if err != nil {
 			log.Print(err)
 		}
 		alerts.Alerts[index].Duration = endsAt_time.Sub(startsAt_time)
-
 	}
 
 	s, err := json.Marshal(alerts)

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ type Alert struct {
 	GeneratorURL string                 `json:"generatorURL"`
 	Labels       map[string]interface{} `json:"labels"`
 	StartsAt     string                 `json:"startsAt"`
-	Duration		 time.Duration
+	Duration     time.Duration
 }
 
 type Config struct {

--- a/main.go
+++ b/main.go
@@ -558,7 +558,7 @@ func POST_Handling(c *gin.Context) {
 		if err != nil {
 			log.Print(err)
 		}
-		alerts.Alerts[index].Duration = endsAt_time.Sub(startsAt_time)
+		alerts.Alerts[index].Duration = endsAt_time.Sub(startsAt_time).Truncate(time.Second)
 	}
 
 	s, err := json.Marshal(alerts)

--- a/main.go
+++ b/main.go
@@ -559,7 +559,8 @@ func POST_Handling(c *gin.Context) {
 		if err != nil {
 			log.Print(err)
 		}
-		alerts.Alerts[index].Duration = endsAt_time.Sub(startsAt_time)
+		// Round to seconds
+		alerts.Alerts[index].Duration = endsAt_time.Sub(startsAt_time).Round(10000000)
 	}
 
 	s, err := json.Marshal(alerts)

--- a/main.go
+++ b/main.go
@@ -320,10 +320,10 @@ func telegramBot(bot *tgbotapi.BotAPI) {
 		log.Fatal(err)
 	}
 
-	introduce := func(update tgbotapi.Update) {
-		msg := tgbotapi.NewMessage(update.Message.Chat.ID, fmt.Sprintf("Chat id is '%d'", update.Message.Chat.ID))
-		bot.Send(msg)
-	}
+	//introduce := func(update tgbotapi.Update) {
+//		msg := tgbotapi.NewMessage(update.Message.Chat.ID, fmt.Sprintf("Chat id is '%d'", update.Message.Chat.ID))
+//		bot.Send(msg)
+//	}
 
 	for update := range updates {
 		if update.Message.NewChatMembers != nil && len(*update.Message.NewChatMembers) > 0 {

--- a/main.go
+++ b/main.go
@@ -319,23 +319,6 @@ func telegramBot(bot *tgbotapi.BotAPI) {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	introduce := func(update tgbotapi.Update) {
-		msg := tgbotapi.NewMessage(update.Message.Chat.ID, fmt.Sprintf("Chat id is '%d'", update.Message.Chat.ID))
-		bot.Send(msg)
-	}
-
-	for update := range updates {
-		if update.Message.NewChatMembers != nil && len(*update.Message.NewChatMembers) > 0 {
-			for _, member := range *update.Message.NewChatMembers {
-				if member.UserName == bot.Self.UserName && update.Message.Chat.Type == "group" {
-					introduce(update)
-				}
-			}
-		} else if update.Message != nil && update.Message.Text != "" {
-			introduce(update)
-		}
-	}
 }
 
 func loadTemplate(tmplPath string) *template.Template {

--- a/main.go
+++ b/main.go
@@ -319,6 +319,23 @@ func telegramBot(bot *tgbotapi.BotAPI) {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	introduce := func(update tgbotapi.Update) {
+		msg := tgbotapi.NewMessage(update.Message.Chat.ID, fmt.Sprintf("Chat id is '%d'", update.Message.Chat.ID))
+		bot.Send(msg)
+	}
+
+	for update := range updates {
+		if update.Message.NewChatMembers != nil && len(*update.Message.NewChatMembers) > 0 {
+			for _, member := range *update.Message.NewChatMembers {
+				if member.UserName == bot.Self.UserName && update.Message.Chat.Type == "group" {
+					//introduce(update)
+				}
+			}
+		} else if update.Message != nil && update.Message.Text != "" {
+			//introduce(update)
+		}
+	}
 }
 
 func loadTemplate(tmplPath string) *template.Template {

--- a/main.go
+++ b/main.go
@@ -559,8 +559,8 @@ func POST_Handling(c *gin.Context) {
 		if err != nil {
 			log.Print(err)
 		}
-		// Round to seconds
-		alerts.Alerts[index].Duration = endsAt_time.Sub(startsAt_time).Round(10000000)
+		alerts.Alerts[index].Duration = endsAt_time.Sub(startsAt_time)
+
 	}
 
 	s, err := json.Marshal(alerts)


### PR DESCRIPTION
Hello,

Added new field "Duration" with time.Duration format , it equals of subtraction between endsAt and startsAt fields.

Example alert resolved: 
`{  
   "alerts":[  
      {  
         "annotations":{  
            "resolve_message":"node-exporter is available test12345",
            "summary":"node-exporter is not available during 5 minute test12345"
         },
         "endsAt":"2018-06-05T09:18:45.237509292Z",
         "generatorURL":"1111",
         "labels":{ 
            "alertname":"Node exporter availability during 5 minute 12345",
            "instance":"22222",
            "severity":"critical"
         },
         "startsAt":"2018-06-05T09:17:45.237509292Z",
         "Duration":60000000000
      }
   ]
}`