### PR TITLE
Add `install_dependencies` to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,7 @@ clean:
 	go clean
 	rm -f $(TARGET)
 	rm -f bot.log
+
+install_dependencies:
+	go get github.com/gin-gonic/gin
+	go get github.com/go-telegram-bot-api/telegram-bot-api


### PR DESCRIPTION
Figuring out the correct dependencies to get after cloning a repository is a little jarring.
This make task installs all of the dependencies that are needed to build `prometheus_bot`.