### PR TITLE
Fixed panics on any message in channel and extending debug output

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-package main // import "github.com/inCaller/prometheus_bot"
+package main // import "github.com/PinGwynn/prometheus_bot"
 
 import (
 	"bytes"
@@ -18,7 +18,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
-	"github.com/go-telegram-bot-api/telegram-bot-api"
+	"gopkg.in/telegram-bot-api.v4"
 	"gopkg.in/yaml.v2"
 
 	"html/template"
@@ -325,6 +325,13 @@ func telegramBot(bot *tgbotapi.BotAPI) {
 	}
 
 	for update := range updates {
+		if update.Message == nil {
+			if *debug {
+				log.Printf("[UNKNOWN_MESSAGE] [%v]", update)
+			}
+			continue
+		}
+
 		if update.Message.NewChatMembers != nil && len(*update.Message.NewChatMembers) > 0 {
 			for _, member := range *update.Message.NewChatMembers {
 				if member.UserName == bot.Self.UserName && update.Message.Chat.Type == "group" {
@@ -395,6 +402,9 @@ func main() {
 	}
 
 	bot = bot_tmp
+	if *debug {
+		bot.Debug = true
+	}
 	if cfg.TemplatePath != "" {
 
 		tmpH = loadTemplate(cfg.TemplatePath)

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-package main // import "github.com/PinGwynn/prometheus_bot"
+package main // import "github.com/inCaller/prometheus_bot"
 
 import (
 	"bytes"


### PR DESCRIPTION
On any message in a channel (not group or supergroup) bot failed with followed message:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xd0 pc=0x156d788]

goroutine 26 [running]:
main.telegramBot(0xc4201ce180)
	/Users/modinintsev/go/src/github.com/PinGwynn/prometheus_bot/main.go:328 +0x178
created by main.main
	/Users/modinintsev/go/src/github.com/PinGwynn/prometheus_bot/main.go:420 +0x36b
```

Fixed by checking that "update.Message" is nil. Also added "bot.Debug" if option -d is passed