### PR TITLE
Multiple templates support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 prometheus_bot
 bot.log
+*.tmpl
 config.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3-alpine3.7 as builder
+FROM golang:1.11-alpine3.7 as builder
 RUN \
     cd / && \
     apk update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN \
     go get -d -v && \
     CGO_ENABLED=0 GOOS=linux go build -v -a -installsuffix cgo -o prometheus_bot 
 
+
 FROM alpine:3.9
 COPY --from=builder /prometheus_bot/prometheus_bot /
 RUN apk add --no-cache ca-certificates tzdata tini

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN \
     cd / && \
     apk update && \
     apk add --no-cache git ca-certificates make tzdata && \
-    git clone https://github.com/inCaller/prometheus_bot && \
+    git clone https://github.com/killmeplz/prometheus_bot && \
     cd prometheus_bot && \
     go get -d -v && \
     CGO_ENABLED=0 GOOS=linux go build -v -a -installsuffix cgo -o prometheus_bot 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ make
     # ONLY IF YOU USING TEMPLATE required for test
 
     template_path: "template.tmpl" 
+    # OPTIONAL TEMPLATES FOR DIFFERENT CHART
+    # map[chatid]templatepath
+    multiple_teplates: 
+      -12138679618923: "template-extra.tmpl" ##
     time_zone: "Europe/Rome"
     split_token: "|"    
 
@@ -82,6 +86,8 @@ To enable template set these settings in your ```config.yaml``` or template will
 ```yml
 telegram_token: "token here"
 template_path: "template.tmpl" # your template file name
+multiple_teplates:  #if you want to specify different templates for different chats
+  -12138679618923: "template-extra.tmpl"
 time_zone: "Europe/Rome" # your time zone check it out from WIKI
 split_token: "|" # token used for split measure label.
 ```

--- a/main.go
+++ b/main.go
@@ -45,13 +45,13 @@ type Alert struct {
 }
 
 type Config struct {
-	TelegramToken     string `yaml:"telegram_token"`
-	TemplatePath      string `yaml:"template_path"`
+	TelegramToken     string            `yaml:"telegram_token"`
+	TemplatePath      string            `yaml:"template_path"`
 	MultipleTemplates map[string]string `yaml:"multiple_templates,omitempty"`
-	TimeZone          string `yaml:"time_zone"`
-	TimeOutFormat     string `yaml:"time_outdata"`
-	SplitChart        string `yaml:"split_token"`
-	SplitMessageBytes int    `yaml:"split_msg_byte"`
+	TimeZone          string            `yaml:"time_zone"`
+	TimeOutFormat     string            `yaml:"time_outdata"`
+	SplitChart        string            `yaml:"split_token"`
+	SplitMessageBytes int               `yaml:"split_msg_byte"`
 }
 
 /**
@@ -297,7 +297,7 @@ var debug = flag.Bool("d", false, "Debug template")
 
 var cfg = Config{}
 var bot *tgbotapi.BotAPI
-var tmpS map[string]*template.Template
+var tmpS = make(map[string]*template.Template)
 
 // Template addictional functions map
 var funcMap = template.FuncMap{
@@ -399,7 +399,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error parsing configuration file: %v", err)
 	}
-
 	if *template_path != "" {
 		cfg.TemplatePath = *template_path
 	}
@@ -545,7 +544,7 @@ func AlertFormatTemplate(alerts Alerts, chatID string) string {
 }
 
 func templateChoose(chatid string) *template.Template {
-	tpl , exists := tmpS[chatid]
+	tpl, exists := tmpS[chatid]
 	if !exists {
 		return tmpS["default"]
 	}

--- a/main.go
+++ b/main.go
@@ -580,6 +580,7 @@ func POST_Handling(c *gin.Context) {
 	log.Println("+-----------------------------------------------------------+\n\n")
 
 	// Decide how format Text
+	log.Println("TemplatePath: " + cfg.TemplatePath)
 	if cfg.TemplatePath == "" {
 		msgtext = AlertFormatStandard(alerts)
 	} else {


### PR DESCRIPTION
For some alertmanager cases like this:
```
route:
  group_by: ['alertname']
  receiver: general
  routes:
   - match:
       job: different
     receiver: cicd

- name: 'general'
  webhook_configs:
  - send_resolved: true
    url: http://telegram-bot:9087/alert/-1234567

- name: 'cicd'
  webhook_configs:
  - send_resolved: true
    url: http://telegram-bot:9087/alert/-1234567889
```