### PR TITLE
Dockerfile Improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 FROM golang:1.10.3-alpine3.7 as builder
 RUN \
     cd / && \
-    apk update && \
     apk add --no-cache git ca-certificates make tzdata && \
     git clone https://github.com/inCaller/prometheus_bot && \
     cd prometheus_bot && \
     go get -d -v && \
     CGO_ENABLED=0 GOOS=linux go build -v -a -installsuffix cgo -o prometheus_bot 
 
-FROM alpine:3.9
+FROM alpine:3.12
 COPY --from=builder /prometheus_bot/prometheus_bot /
 RUN apk add --no-cache ca-certificates tzdata tini
 USER nobody

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3-alpine3.7 as builder
+FROM golang:1.14.4-alpine3.12 as builder
 RUN \
     cd / && \
     apk add --no-cache git ca-certificates make tzdata && \


### PR DESCRIPTION
1) `apk update` is unnecessary when you use `apk add --no-cache`.
2) I assume (have successfully built this new Dockerfile) bumping go and alpine version doesn't do any harm.