### PR TITLE
Add send_only config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ make
     template_path: "template.tmpl" # ONLY IF YOU USING TEMPLATE
     time_zone: "Europe/Rome" # ONLY IF YOU USING TEMPLATE
     split_msg_byte: 4000
+    send_only: false # use bot only to send messages.
     ```
 
 3. Run ```telegram_bot```. See ```prometheus_bot --help``` for command line options

--- a/main.go
+++ b/main.go
@@ -428,7 +428,9 @@ func main() {
 
 	log.Printf("Authorised on account %s", bot.Self.UserName)
 
-	if !cfg.SendOnly {
+	if cfg.SendOnly {
+		log.Printf("Works in send_only mode")
+	} else {
 		go telegramBot(bot)
 	}
 

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ type Config struct {
 	TimeOutFormat     string `yaml:"time_outdata"`
 	SplitChart        string `yaml:"split_token"`
 	SplitMessageBytes int    `yaml:"split_msg_byte"`
+	SendOnly          bool   `yaml:"send_only"`
 }
 
 /**
@@ -427,7 +428,9 @@ func main() {
 
 	log.Printf("Authorised on account %s", bot.Self.UserName)
 
-	go telegramBot(bot)
+	if !cfg.SendOnly {
+		go telegramBot(bot)
+	}
 
 	router := gin.Default()
 


### PR DESCRIPTION
Add `send_only: false` config to use bot only to send messages and stop listening for updates.  
It's useful for example if you want to use one bot in multiple projects, without `send_only: true` you cann't do it because telegram throws error because multiple instances listening for the bot updates