### PR TITLE
Add missing 'Status' to Alert struct.

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ type Alert struct {
 	GeneratorURL string                 `json:"generatorURL"`
 	Labels       map[string]interface{} `json:"labels"`
 	StartsAt     string                 `json:"startsAt"`
+	Status       string                 `json:"status"`
 }
 
 type Config struct {


### PR DESCRIPTION
See https://prometheus.io/docs/alerting/latest/notifications/#alert .

This field is required to use templates like this

{{ range .Alerts }}
{{ if eq .Status "firing"}}🔥<b>{{ .Status | str_UpperCase }}</b>🔥{{ end }}
{{ end }}