### PR TITLE
add status in Alert type

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ type Alerts struct {
 }
 
 type Alert struct {
+	Status       string                 `json:"status"`
 	Annotations  map[string]interface{} `json:"annotations"`
 	EndsAt       string                 `json:"endsAt"`
 	GeneratorURL string                 `json:"generatorURL"`


### PR DESCRIPTION
in previous versions you use one status.
when you use group and alert manager sends multiple alerts in one json. if one of them is fired and others is resolved it says the status is fired but for each of those alerts there is a specific status that says the real status. 
you can see the json sample in [here](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config)


![Screenshot from 2021-05-23 19-01-53](https://user-images.githubusercontent.com/20243590/119264742-92424700-bbf9-11eb-80e4-26e2fae208d0.png)
as you can see there are two statuses

with adding this line the code can support 