### PR TITLE
Fixed error on debug mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -414,9 +414,6 @@ func main() {
 		cfg.SplitMessageBytes = 4000
 	}
 
-	if *debug {
-		bot.Debug = true
-	}
 	if cfg.TemplatePath != "" {
 
 		tmpH = loadTemplate(cfg.TemplatePath)
@@ -443,6 +440,10 @@ func main() {
 			log.Printf("Error initializing telegram connection: %s", err)
 			time.Sleep(time.Second)
 		}
+	}
+
+	if *debug {
+		bot.Debug = true
 	}
 
 	log.Printf("Authorised on account %s", bot.Self.UserName)


### PR DESCRIPTION
Error on debug mode:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x89dae0]

goroutine 1 [running]:
main.main()
        /prometheus_bot/main.go:418 +0x260
```
Moved debug definition after bot initialization.