### PR TITLE
Resolve build warning for FromAsCasing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.3-alpine as builder
+FROM golang:1.22.3-alpine AS builder
 WORKDIR /app
 COPY go.mod .
 COPY go.sum .
@@ -7,7 +7,7 @@ COPY . .
 RUN GOGC=off CGO_ENABLED=0 go build -v -o prometheus_bot
 
 
-FROM alpine:3.19 as alpine
+FROM alpine:3.19 AS alpine
 RUN apk add --no-cache ca-certificates tzdata
 
 


### PR DESCRIPTION
When running the `docker build .` command, the following warnings are displayed due to inconsistent casing of `AS` in multi-stage builds:

```
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 9)
```

This PR resolves the warnings by standardizing the casing of the `AS` keyword to align with `FROM`, as recommended by Dockerfile best practices. 