### PR TITLE
Consolidate copy directives for go.mod and go.sum in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM golang:1.22.3-alpine as builder
 WORKDIR /app
-COPY go.mod .
-COPY go.sum .
+COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN GOGC=off CGO_ENABLED=0 go build -v -o prometheus_bot


### PR DESCRIPTION
Consolidates the `COPY` directives for `go.mod` and `go.sum` into a single line for simplicity.
