### PR TITLE
Resolve warning by initializing j1 with initial argument

### DIFF
--- a/main.go
+++ b/main.go
@@ -161,7 +161,7 @@ func str_Format_MeasureUnit(MeasureUnit string, value string) string {
 }
 
 // Scale number for It measure unit
-func str_Format_Byte(in string, j1 int) string {
+func str_Format_Byte(in string, initial int) string {
 	var str_Size string
 
 	f, err := strconv.ParseFloat(in, 64)
@@ -170,7 +170,7 @@ func str_Format_Byte(in string, j1 int) string {
 		panic(err)
 	}
 
-	for j1 = 0; j1 < (Information_Size_MAX + 1); j1++ {
+	for j1 := initial; j1 < (Information_Size_MAX + 1); j1++ {
 
 		if j1 >= Information_Size_MAX {
 			str_Size = "Yb"
@@ -206,7 +206,7 @@ func str_Format_Byte(in string, j1 int) string {
 }
 
 // Format number for fisics measure unit
-func str_Format_Scale(in string, j1 int) string {
+func str_Format_Scale(in string, initial int) string {
 	var str_Size string
 
 	f, err := strconv.ParseFloat(in, 64)
@@ -215,7 +215,7 @@ func str_Format_Scale(in string, j1 int) string {
 		panic(err)
 	}
 
-	for j1 = 0; j1 < (Scale_Size_MAX + 1); j1++ {
+	for j1 := initial; j1 < (Scale_Size_MAX + 1); j1++ {
 
 		if j1 >= Scale_Size_MAX {
 			str_Size = "Y"


### PR DESCRIPTION
This PR resolves a warning related to overwriting the `j1` variable before it is first used by initializing it with the `initial` argument in the `str_Format_Scale` and `str_Format_Byte` functions.
