### PR TITLE
Add error handling for router.Run

### DIFF
--- a/main.go
+++ b/main.go
@@ -458,7 +458,11 @@ func main() {
 	router.GET("/ping/:chatid/:topicid", GET_Handling)
 	router.POST("/alert/:chatid", POST_Handling)
 	router.POST("/alert/:chatid/:topicid", POST_Handling)
-	router.Run(*listen_addr)
+
+	err = router.Run(*listen_addr)
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 func GET_Handling(c *gin.Context) {


### PR DESCRIPTION
This PR adds error handling for `router.Run`, specifically addressing cases where the port is already occupied by another program. If an error occurs, it will be logged and the program will terminate.